### PR TITLE
Added aggregation of AMS Weekly Incident Reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ After deploying the CloudFormation templates provided in this package, AMS SSR r
 - `DailyBackupCrawlerSchedule` is a cron expression representing the time the Glue Crawler should crawl for new reports. The cron expects 6 parts separated by whitespace, for example `cron(0 21 * * ? *)`
 - `PatchDetailsCrawlerSchedule` is a cron expression representing the time the Glue Crawler should crawl for new reports. The cron expects 6 parts separated by whitespace, for example `cron(0 21 * * ? *)`
 - `InstanceDetailsCrawlerSchedule` is a cron expression representing the time the Glue Crawler should crawl for new reports. The cron expects 6 parts separated by whitespace, for example `cron(0 21 * * ? *)`
+- `WeeklyIncidentReportCrawlerSchedule` is a cron expression representing the time the Glue Crawler should crawl for new reports. The cron expects 6 parts separated by whitespace, for example `cron(0 21 ? * MON *)`
 - `WindowsMissingCrawlerSchedule` is a cron expression representing the time the Glue Crawler should crawl for new reports. The cron expects 6 parts separated by whitespace, for example `cron(0 21 * * ? *)`
 
-_This package expects AMS SSR to publish new SSR reports into your AMS-Managed AWS Account by 21:00 UTC each day._
+_This package expects AMS SSR to publish new SSR reports into your AMS-Managed AWS Account by 21:00 UTC each day (or, for the Weekly Incident Report, weekly)._
 
 #### CloudFormation Outputs:
 
@@ -85,7 +86,7 @@ The CloudFormation template `template-aggregation-account.yml` deploys an IAM Ma
 
 ### Querying the aggregated data
 
-To get started querying aggregated data, from the Athena Console in the report aggregation account, 4x example "Saved Queries" have been provided. These queries are accessible via the `Saved Query` tab within the `ams-report-aggregator-workgroup` Athena Workgroup. These queries are intended as examples only. As this is an Open Source project, contributions from the community are welcome. See [CONTRIBUTING](CONTRIBUTING.md) for more information.
+To get started querying aggregated data, from the Athena Console in the report aggregation account, 5x example "Saved Queries" have been provided. These queries are accessible via the `Saved Query` tab within the `ams-report-aggregator-workgroup` Athena Workgroup. These queries are intended as examples only. As this is an Open Source project, contributions from the community are welcome. See [CONTRIBUTING](CONTRIBUTING.md) for more information.
 
 ![SSR Saved Athena Queries](images/saved-queries.png)
 

--- a/template-aggregation-account.yml
+++ b/template-aggregation-account.yml
@@ -42,6 +42,11 @@ Parameters:
     AllowedPattern: ^cron\((\S+\s){5}\S+\)$
     Default: cron(0 21 * * ? *)
     Description: The time at which the Windows Missing Crawler will be scheduled to run (default - 9pm UTC every day)
+  WeeklyIncidentReportCrawlerSchedule:
+    Type: String
+    AllowedPattern: ^cron\((\S+\s){5}\S+\)$
+    Default: cron(0 21 ? * MON *)
+    Description: The time at which the Incident Report will be scheduled to run (default - 9pm UTC every Monday)
 Resources:
   AggregatorKMSKey:
     Type: AWS::KMS::Key
@@ -197,6 +202,42 @@ Resources:
       WorkGroupConfiguration:
         ResultConfiguration:
           OutputLocation: !Sub "s3://${AggregatorAthenaWorkgroupBucket}/queryresults/"
+  AggregatorExplicitDenyAMSResourcesPolicy:
+    # AMS deploys resources into customer accounts which are necessary for the operation
+    # of the AMS Service. This policy, when attached to IAM Roles in this template, prevents those
+    # Principals from mutating AMS Managed Resources through the use of explicit deny statements.
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Explicitly denies Glue and CloudWatch actions on AMS Management Resources
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: ExplicitDenyAMSManagedLogResources
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Effect: Deny
+            Resource:
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/AMS/*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/Ams/*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/ams/*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/AMS*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/Ams*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/ams*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/AMS*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/Ams*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/ams*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/mc/*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/MC/*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/Mc/*
+          - Sid: ExplicitDenyAMSManagedGlueResources
+            Action:
+              - glue:*
+            Effect: Deny
+            Resource:
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:ams*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:mc-a*-internal-*
   AggregatorDB:
     Type: AWS::Glue::Database
     Properties:
@@ -295,42 +336,6 @@ Resources:
             Parameters:
               serialization.format: "1"
         TableType: EXTERNAL_TABLE
-  AggregatorExplicitDenyAMSResourcesPolicy:
-    # AMS deploys resources into customer accounts which are necessary for the operation
-    # of the AMS Service. This policy, when attached to IAM Roles in this template, prevents those
-    # Principals from mutating AMS Managed Resources through the use of explicit deny statements.
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      Description: Explicitly denies Glue and CloudWatch actions on AMS Management Resources
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Sid: ExplicitDenyAMSManagedLogResources
-            Action:
-              - logs:CreateLogGroup
-              - logs:CreateLogStream
-              - logs:PutLogEvents
-            Effect: Deny
-            Resource:
-              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/AMS/*
-              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/Ams/*
-              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/ams/*
-              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/AMS*
-              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/Ams*
-              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/ams*
-              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/AMS*
-              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/Ams*
-              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/ams*
-              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/mc/*
-              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/MC/*
-              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/Mc/*
-          - Sid: ExplicitDenyAMSManagedGlueResources
-            Action:
-              - glue:*
-            Effect: Deny
-            Resource:
-              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:ams*
-              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:mc-a*-internal-*
   AggregatorPatchDetailsCrawlerRole:
     Type: AWS::IAM::Role
     Properties:
@@ -641,7 +646,7 @@ Resources:
       Description: Scheduled to crawl 'Instance Details Patch Orchestrator' reports daily.
       Role: !GetAtt AggregatorInstanceDetailsPOCrawlerRole.Arn
       Schedule:
-        ScheduleExpression: !Ref DailyBackupCrawlerSchedule
+        ScheduleExpression: !Ref InstanceDetailsCrawlerSchedule
       Targets:
         CatalogTargets:
           - DatabaseName: !Ref AggregatorDB
@@ -845,6 +850,111 @@ Resources:
       SchemaChangePolicy:
         DeleteBehavior: LOG
         UpdateBehavior: UPDATE_IN_DATABASE
+  AggregatorWeeklyIncidentReportTable:
+    Type: AWS::Glue::Table
+    Properties:
+      CatalogId: !Ref "AWS::AccountId"
+      DatabaseName: !Ref "AggregatorDB"
+      TableInput:
+        Name: amsaggregatorweeklyincidentreport
+        PartitionKeys:
+          - Name: reportdate
+            Type: string
+          - Name: awsaccountid
+            Type: string
+        StorageDescriptor:
+          Columns:
+            - Name: dataset_datetime
+              Type: string
+            - Name: aws_account_id
+              Type: string
+            - Name: account_name
+              Type: string
+            - Name: case_id
+              Type: string
+            - Name: created_month
+              Type: string
+            - Name: priority
+              Type: string
+            - Name: severity
+              Type: string
+            - Name: status
+              Type: string
+            - Name: yuma_category
+              Type: string
+          Location: !Sub "s3://${AggregatorAggregationBucket}/incident/weeklyincidentreport"
+          InputFormat: org.apache.hadoop.mapred.TextInputFormat
+          OutputFormat: org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat
+          SerdeInfo:
+            SerializationLibrary: org.openx.data.jsonserde.JsonSerDe
+            Parameters:
+              serialization.format: "1"
+        TableType: EXTERNAL_TABLE
+  AggregatorWeeklyIncidentReportCrawlerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: glue.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSGlueServiceRole
+        - !Ref AggregatorExplicitDenyAMSResourcesPolicy
+  AggregatorWeeklyIncidentReportCrawlerRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: GlueCrawlerLogging
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Effect: Allow
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
+          - Sid: GlueCrawlerMutate
+            Action:
+              - glue:CreateTable
+              - glue:ImportCatalogToGlue
+              - glue:UpdateDatabase
+              - glue:UpdatePartition
+              - glue:UpdateTable
+            Effect: Allow
+            Resource: !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:*
+          - Sid: GlueCrawlerS3Read
+            Action: s3:GetObject
+            Effect: Allow
+            Resource:
+              - !GetAtt AggregatorAggregationBucket.Arn
+              - !Sub "${AggregatorAggregationBucket.Arn}/incident/weeklyincidentreport/*"
+          - Sid: GlueCrawlerDecryptObjects
+            Action: kms:Decrypt
+            Effect: Allow
+            Resource: !GetAtt AggregatorKMSKey.Arn
+      PolicyName: AggregatorWeeklyIncidentReportCrawlerRolePolicy
+      Roles:
+        - Ref: AggregatorWeeklyIncidentReportCrawlerRole
+  AggregatorWeeklyIncidentReportCrawler:
+    Type: AWS::Glue::Crawler
+    Properties:
+      Description: Scheduled to crawl 'Weekly Incident' reports weekly.
+      Role: !GetAtt AggregatorWeeklyIncidentReportCrawlerRole.Arn
+      Schedule:
+        ScheduleExpression: !Ref WeeklyIncidentReportCrawlerSchedule
+      Targets:
+        CatalogTargets:
+          - DatabaseName: !Ref AggregatorDB
+            Tables:
+              - !Ref AggregatorWeeklyIncidentReportTable
+      DatabaseName: !Ref AggregatorDB
+      Name: aggregatorcrawler-weeklyincidentreport
+      SchemaChangePolicy:
+        DeleteBehavior: LOG
+        UpdateBehavior: UPDATE_IN_DATABASE
   QueryYesterdaysPatchStatusOfEC2Instances:
     Type: AWS::Athena::NamedQuery
     Properties:
@@ -935,6 +1045,17 @@ Resources:
           reportdate = cast((current_date) as varchar)
         AND
           backup_job_status != 'COMPLETED'
+  QueryWeeklyIncidentReportForDate:
+    Type: AWS::Athena::NamedQuery
+    Properties:
+      WorkGroup: !Ref AggregatorAthenaWorkgroup
+      Database: !Ref AggregatorDB
+      Description: Example query, returns all Incidents that appear in the weekly report for a given date
+      Name: Incident-AllWeeklyIncidentsForReportDate
+      QueryString: |
+        SELECT *
+        FROM amsaggregatordatabase.amsaggregatorweeklyincidentreport
+        WHERE reportdate='2023-05-15'
   AggregatorAthenaPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -987,3 +1108,4 @@ Outputs:
     Value: !Ref AggregatorAthenaPolicy
     Export:
       Name: AggregatorAthenaPolicyArn
+

--- a/template-member-accounts.yml
+++ b/template-member-accounts.yml
@@ -82,6 +82,7 @@ Resources:
           WINDOWS_MISSING_REGEX = r"^json\/patch\/windows_missing_patches\/Date=(\d{4}-\d{2}-\d{2})\/(.+).json$"
           INSTANCE_DETAILS_REGEX = r"^json\/patch\/instance_details_patch_orchestrator\/Date=(\d{4}-\d{2}-\d{2})\/(.+).json$"
           DAILY_BACKUP_REGEX = r"^json\/backup\/daily_backup_report\/Date=(\d{4}-\d{2}-\d{2})\/(.+).json$"
+          WEEKLY_INCIDENT_REPORT_REGEX = r"^json\/incident\/weekly_incident_report\/Date=(\d{4}-\d{2}-\d{2})\/(.+).json$"
 
           s3_resource = boto3.resource("s3")
 
@@ -107,6 +108,7 @@ Resources:
               "patch/windowsmissingpatches": WINDOWS_MISSING_REGEX,
               "patch/instancedetailspatchorchestrator": INSTANCE_DETAILS_REGEX,
               "backup/dailybackupreport": DAILY_BACKUP_REGEX,
+              "incident/weeklyincidentreport": WEEKLY_INCIDENT_REPORT_REGEX,
             }
 
             regex_to_use = ""
@@ -121,7 +123,8 @@ Resources:
             
 
             if len(key_matches) == 4:
-              destination_s3_key = f"{report_type}/reportdate={key_matches[1]}/awsaccountid={AWS_ACCOUNT_ID}/{key_matches[2]}.json" 
+              filename = urllib.parse.quote(key_matches[2], encoding="utf-8")
+              destination_s3_key = f"{report_type}/reportdate={key_matches[1]}/awsaccountid={AWS_ACCOUNT_ID}/{filename}.json" 
 
               try:
                 destination_bucket = s3_resource.Bucket(REPORT_AGGREGATE_BUCKET_NAME)
@@ -314,3 +317,4 @@ Resources:
       ServiceToken: !GetAtt S3LambdaIntegrationCustomResourceFunction.Arn
       LambdaArn: !GetAtt ReportAggregatorFunction.Arn
       Bucket: !Sub ams-reporting-data-a${AWS::AccountId}
+


### PR DESCRIPTION
*Description of changes:*

Per our discussion, a customer I am working with wanted to aggregate AMS Weekly Incident Reports. This pull request aggregates those reports in the same way as the existing patch and backup reports in the current solution, but the refresh schedule for Weekly Incident Reports is weekly rather than daily.
Also fixed the mapping of the schedule parameter for instance details.